### PR TITLE
Enable to set clone locations with env

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,9 +1,9 @@
 require 'rubygems'
 
 Gem.post_install do |installer|
+  clone_root = ENV['GEMSRC_CLONE_ROOT'] || installer.gem_dir
+  clone_dir = ENV['GEMSRC_CLONE_DIR'] || (clone_root == installer.gem_dir ? 'src' : installer.spec.name)
   if installer.spec.homepage && !installer.spec.homepage.empty? && !File.exists?("#{installer.gem_dir}/src") && !`git ls-remote #{installer.spec.homepage} 2> /dev/null`.empty?
-    Dir.chdir installer.gem_dir do
-      `git clone #{installer.spec.homepage} src`
-    end
+    `git clone #{installer.spec.homepage} #{clone_root}/#{clone_dir}`
   end
 end


### PR DESCRIPTION
This patch enables users to specify the destination directory of cloning gems with two environment vars:
- GEMSRC_CLONE_ROOT: the root directory to clone
- GEMSRC_CLONE_DIR: the directory name of root of repository

Examples:

``` sh
GEMSRC_CLONE_ROOT=$HOME/repos gem install gem-src
GEMSRC_CLONE_DIR=src gem install gem-src
```
