### PR TITLE
Error handling for HTTPError of open-uri.

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -40,6 +40,8 @@ module Gem
     def api
       require 'open-uri'
       @api ||= open("http://rubygems.org/api/v1/gems/#{installer.spec.name}.yaml", &:read)
+    rescue OpenURI::HTTPError
+      ""
     end
 
     def source_code_uri


### PR DESCRIPTION
If gem-src got exception when multiple gem install, it break install process. I fixed this breaks.
