### PR TITLE
require https instead of http to resolve undefined use_ssl= error in ruby 1.8

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'net/http'
+require 'net/https'
 
 module Gem
   class Src


### PR DESCRIPTION
In Ruby 1.8, I keep getting this error when installing gem.

```
$ rbenv global 1.8.7-p352
$ gem install rspec
Fetching: rspec-core-2.14.8.gem (100%)
ERROR:  While executing gem ... (NoMethodError)
    undefined method `use_ssl=' for #<Net::HTTP github.com:443 open=false>
```

We should require https instead of http so that the method use_ssl= will be available in ruby 1.8.
