### PR TITLE
Add support for ghq

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -70,7 +70,16 @@ module Gem
       return if @tested_repositories.include? repository
       @tested_repositories << repository
       return if github?(repository) && !github_page_exists?(repository)
-      system 'git', 'clone', repository, clone_dir if git?(repository)
+
+      if ghq_available?
+        system 'ghq', 'get', repository
+      else
+        system 'git', 'clone', repository, clone_dir if git?(repository)
+      end
+    end
+
+    def ghq_available?
+      system('which', 'ghq')
     end
 
     def git_clone_homepage_or_source_code_uri_or_homepage_uri_or_github_organization_uri


### PR DESCRIPTION
`ghq` is a tool which is developed by @motemen and allows us to manage cloned repos easily.

http://motemen.hatenablog.com/entry/2014/06/01/introducing-ghq

I'm convinced that it must be useful gem-src uses ghq instead of its original cloning strategy.

output:

```
$ gem i glint
Fetching: glint-0.0.2.gem (100%)
/Users/usr0600239/bin/ghq
     clone http://github.com/kentaro/glint -> /Users/usr0600239/src/github.com/kentaro/glint
       git clone http://github.com/kentaro/glint /Users/usr0600239/src/github.com/kentaro/glint
Cloning into '/Users/usr0600239/src/github.com/kentaro/glint'...
remote: Reusing existing pack: 185, done.
remote: Total 185 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (185/185), 20.76 KiB, done.
Resolving deltas: 100% (61/61), done.
Successfully installed glint-0.0.2
1 gem installed
```
