### PR TITLE
Skip clone gem when passed 'GEMSRC_SKIP'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ When you firstly installed this gem, you might want to type in this command righ
     % gem pristine --all
 This will reinstall all the already installed gems, and so will `git clone` all the repos.
 
+## Skip clone
+
+When you want to skip cloning to repository, you can skip to clone with below command.
+
+    % GEMSRC_SKIP=true bundle install
+
 
 ## Contributing
 

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -83,6 +83,7 @@ module Gem
     end
 
     def git_clone_homepage_or_source_code_uri_or_homepage_uri_or_github_organization_uri
+      return false if skip_clone?
       return false if File.exist? clone_dir
       git_clone(installer.spec.homepage) ||
         git_clone(github_url(installer.spec.homepage)) ||
@@ -95,6 +96,10 @@ module Gem
     def api_uri_for(key)
       uri = api[Regexp.new("^#{key}_uri: (.*)$"), 1]
       uri =~ /\Ahttps?:\/\// ? uri : nil
+    end
+
+    def skip_clone?
+      !!ENV["GEMSRC_SKIP"]
     end
   end
 end


### PR DESCRIPTION
I use `bundle install --force` command often  for re-install several gems.
It takes much time by non cloneable url in gemspec.
Or, sometimes want to skip clone explicitly.

## in my case
- [Gemfile](https://github.com/unasuke/proconist.net/blob/fb075a55eb961b5c4d9e77ae87b031b98adddf5d/Gemfile)
- [Gemfile.lock](https://github.com/unasuke/proconist.net/blob/fb075a55eb961b5c4d9e77ae87b031b98adddf5d/Gemfile.lock)

### `bundle install --force`
```shell
% time bundle install --force
Installing rake 11.2.2
    exists /Users/unasuke/src/github.com/ruby/rake
(snip)...
Bundle complete! 28 Gemfile dependencies, 97 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
bundle install --force  48.37s user 26.60s system 24% cpu 5:11.44 total
```

mean of 5 times : `5:07.43`

### `GEMSRC_SKIP=true bundle install --force`
```shell
% time GEMSRC_SKIP=true bundle install --force
Installing rake 11.2.2
Installing concurrent-ruby 1.0.2
(snip)...
Bundle complete! 28 Gemfile dependencies, 97 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
GEMSRC_SKIP=true bundle install --force  42.75s user 20.86s system 99% cpu 1:03.72 total
```
mean of 5 times : `1:04.55`
