### PR TITLE
Suppress redefined warnings with rubygems test suite

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -149,7 +149,7 @@ module Gem
     def verbose?
       !!ENV['GEMSRC_VERBOSE'] || Gem.configuration[:gemsrc_verbose]
     end
-  end
+  end unless defined?(Src) # for rubygems test suite.
 end
 
 


### PR DESCRIPTION
Fixes #18

But this seems dirty workaround