### PR TITLE
Check cloneable by git

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -121,6 +121,7 @@ module Gem
       return if @tested_repositories.include? repository
       @tested_repositories << repository
       return if github?(repository) && !github_page_exists?(repository)
+      return unless system 'git', 'ls-remote', repository, 'HEAD'
 
       puts "gem-src: #{installer.spec.name} - Cloning from #{repository}..." if verbose?
 


### PR DESCRIPTION
In my case, I am using ghq.
gem-src many send requests to the hompage when execute `gem i bundler` but that is not url for git.
It takes many time so I want to check it is git url before execute `git clone #{repository}`.


## Actual behaviour
```console
$ gem i bundler
Fetching: bundler-1.16.1.gem (100%)
     clone http://bundler.io -> /home/sachin21dev/Projects/bundler.io
        hg identify http://bundler.io
       git ls-remote http://bundler.io
       svn info http://bundler.io
     error Could not find version control system: http://bundler.io
     clone http://github.com/bundler/bundler/ -> /home/sachin21dev/Projects/github.com/bundler/bundler
       git clone http://github.com/bundler/bundler/ /home/sachin21dev/Projects/github.com/bundler/bundler
Cloning into '/home/sachin21dev/Projects/github.com/bundler/bundler'...
warning: redirecting to https://github.com/bundler/bundler/
remote: Counting objects: 75095, done.
remote: Total 75095 (delta 0), reused 0 (delta 0), pack-reused 75095
Receiving objects: 100% (75095/75095), 32.94 MiB | 5.83 MiB/s, done.
Resolving deltas: 100% (48231/48231), done.
Successfully installed bundler-1.16.1
1 gem installed
```

## Expected behaviour

```console
$ gem i bundler
Fetching: bundler-1.16.1.gem (100%)
     clone http://github.com/bundler/bundler/ -> /home/sachin21dev/Projects/github.com/bundler/bundler
       git clone http://github.com/bundler/bundler/ /home/sachin21dev/Projects/github.com/bundler/bundler
Cloning into '/home/sachin21dev/Projects/github.com/bundler/bundler'...
warning: redirecting to https://github.com/bundler/bundler/
remote: Counting objects: 75095, done.
remote: Total 75095 (delta 0), reused 0 (delta 0), pack-reused 75095
Receiving objects: 100% (75095/75095), 32.94 MiB | 8.74 MiB/s, done.
Resolving deltas: 100% (48231/48231), done.
Successfully installed bundler-1.16.1
1 gem installed
```