### PR TITLE
Ignore warning for Kernel#open.

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -98,7 +98,7 @@ module Gem
 
     def api
       require 'open-uri'
-      @api ||= open("https://rubygems.org/api/v1/gems/#{installer.spec.name}.yaml", &:read)
+      @api ||= URI.open("https://rubygems.org/api/v1/gems/#{installer.spec.name}.yaml", &:read)
     rescue OpenURI::HTTPError
       ""
     end


### PR DESCRIPTION
I got the following message with Ruby 2.7.

```
gem-src/lib/rubygems_plugin.rb:101: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly
```