### PR TITLE
Fix error: private method `open' called for URI:Module

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -98,7 +98,7 @@ module Gem
 
     def api
       require 'open-uri'
-      @api ||= URI.open("https://rubygems.org/api/v1/gems/#{installer.spec.name}.yaml", &:read)
+      @api ||= OpenURI.open_uri("https://rubygems.org/api/v1/gems/#{installer.spec.name}.yaml", &:read)
     rescue OpenURI::HTTPError
       ""
     end


### PR DESCRIPTION
In ruby version < 2.5, `URI.open` is private method

```
root@107ef8fe8980:/all-ruby# ALL_RUBY_SINCE=ruby-2.0.0 ./all-ruby -ropen-uri -e 'p URI.respond_to?(:open)'
ruby-2.0.0-p0       false
...
ruby-2.5.0-rc1      false
ruby-2.5.0          true
...
ruby-2.7.0-preview3 true
```

I've got following error when install bundler.

```
% ruby -v
ruby 2.4.9p362 (2019-10-02 revision 67824) [x86_64-linux]
% gem i bundler
Fetching: bundler-2.0.2.gem (100%)
     clone https://bundler.io -> /home/sei/src/bundler.io
     error Could not find version control system: https://bundler.io
ERROR:  While executing gem ... (NoMethodError)
    private method `open' called for URI:Module
```